### PR TITLE
Revert "Bump actions/upload-pages-artifact from 3 to 4"

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -61,7 +61,7 @@ jobs:
             --minify \
             --baseURL "${{ steps.pages.outputs.base_url }}/"
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v4
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./public
 


### PR DESCRIPTION
Reverts thespad/thespad.github.io#64 due to breaking .well-known